### PR TITLE
Add CORS support for the redirect

### DIFF
--- a/conf/0-linked.data.gov.au.conf
+++ b/conf/0-linked.data.gov.au.conf
@@ -20,6 +20,10 @@
 
 	RewriteRule ^/robots.txt /var/www/html/robots.txt [L]
 
+        #CORS
+        Header set Access-Control-Allow-Origin "*"
+
+
         #
         #	PIDs
         #


### PR DESCRIPTION
In some clients, such as JS frontends, the PIDs can't be used as CORS isn't enabled. Example given below and how to check using CURL.
```
$ curl -H "Access-Control-Request-Method: GET" -H "Origin: http://localhost" --head http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel4/801

HTTP/1.1 302 Found
Date: Wed, 25 Mar 2020 12:09:32 GMT
Server: Apache/2.4.29 (Ubuntu)
Location: http://asgsld.net/2016/statisticalarealevel4/801
Content-Type: text/html; charset=iso-8859-1
```
(response does not include Access-Control-Allow-* which means resource does not support CORS).

This PR adds a config to enable CORS.
