### PR TITLE
TERN vocabs - redirect to https instead of http

### DIFF
--- a/conf/linked.data.gov.au-vocabularies.conf
+++ b/conf/linked.data.gov.au-vocabularies.conf
@@ -33,9 +33,9 @@
         RewriteCond %{HTTP:Accept} text/turtle [NC]
         RewriteRule ^/def/ausplots-cv$                          https://linkeddata.tern.org.au/viewer/tern/download [R=302,L]
         RewriteRule ^/def/ausplots-cv$                          https://linkeddata.tern.org.au/viewer/tern/ [R=302,L]
-        RewriteRule ^/def/ausplots-cv(.*)$                      http://linkeddata.tern.org.au/viewer/ausplots/id/http://%{SERVER_NAME}%{REQUEST_URI} [R=302,L]
-        RewriteRule ^/def/tern-cv/$                             http://linkeddata.tern.org.au/viewer/tern/vocabulary/ [R=302,L]
-        RewriteRule ^/def/tern-cv(.*)$                          http://linkeddata.tern.org.au/viewer/tern/id/http://%{SERVER_NAME}%{REQUEST_URI} [R=302,L]
+        RewriteRule ^/def/ausplots-cv(.*)$                      https://linkeddata.tern.org.au/viewer/ausplots/id/http://%{SERVER_NAME}%{REQUEST_URI} [R=302,L]
+        RewriteRule ^/def/tern-cv/$                             https://linkeddata.tern.org.au/viewer/tern/vocabulary/ [R=302,L]
+        RewriteRule ^/def/tern-cv(.*)$                          https://linkeddata.tern.org.au/viewer/tern/id/http://%{SERVER_NAME}%{REQUEST_URI} [R=302,L]
 
 
         # https://linked.data.gov.au/def/australian-phone-area-codes
@@ -50,11 +50,11 @@
         RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
         RewriteCond %{HTTP:Accept} text/turtle [NC]
         RewriteRule ^/def/corveg-cv$                            https://linkeddata.tern.org.au/viewer/corveg/download [R=302,L]
-        RewriteRule ^/def/corveg-cv$                            http://linkeddata.tern.org.au/viewer/corveg/ [R=302,L] 
+        RewriteRule ^/def/corveg-cv$                            https://linkeddata.tern.org.au/viewer/corveg/ [R=302,L] 
         RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
         RewriteCond %{HTTP:Accept} text/turtle [NC] 
-        RewriteRule ^/def/corveg-cv(.*)                         http://linkeddata.tern.org.au/viewer/corveg/id/http://linked.data.gov.au/def/corveg-cv$1?_format=text/turtle [R=302,L]	
-        RewriteRule ^/def/corveg-cv(.*)                         http://linkeddata.tern.org.au/viewer/corveg/id/http://linked.data.gov.au/def/corveg-cv$1 [R=302,L]
+        RewriteRule ^/def/corveg-cv(.*)                         https://linkeddata.tern.org.au/viewer/corveg/id/http://linked.data.gov.au/def/corveg-cv$1?_format=text/turtle [R=302,L]	
+        RewriteRule ^/def/corveg-cv(.*)                         https://linkeddata.tern.org.au/viewer/corveg/id/http://linked.data.gov.au/def/corveg-cv$1 [R=302,L]
     
 
         # http://linked.data.gov.au/def/gba


### PR DESCRIPTION
The redirect to http is causing issues with some of TERN's systems.