### PR TITLE
Restore use of local images for legacy/tombstone pages

### DIFF
--- a/html/environment.data.gov.au.html
+++ b/html/environment.data.gov.au.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="favicon" type="image/png" href="https://www.linked.data.gov.au/style/img/agldwg-logo.ico" />
+    <link rel="icon" href="style/img/agldwg-logo.ico" />
     <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="https://www.linked.data.gov.au/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -52,7 +52,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="https://www.linked.data.gov.au/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/tombstoned.html
+++ b/html/tombstoned.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="favicon" type="image/png" href="https://www.linked.data.gov.au/style/img/agldwg-logo.ico" />
+    <link rel="icon" href="style/img/agldwg-logo.ico" />
     <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="https://www.linked.data.gov.au/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -47,7 +47,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="https://www.linked.data.gov.au/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">


### PR DESCRIPTION
In the environment and tombstone pages, use local links for images.

(For environment.data.gov.au.html, this restores a previous change.)