### PR TITLE
Add slash prefix for local static hrefs

### DIFF
--- a/html/404.html
+++ b/html/404.html
@@ -15,14 +15,14 @@
     <meta name="description" content="Home page of the Australian Government Linked Data Working Group" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
 
     <style>
         body {
             font-family: Roboto,sans-serif;
             font-weight: 300;
             color: rgb(133, 25, 2);
-            background: url("style/img/comms_bg_grey.svg") top right no-repeat;
+            background: url("/style/img/comms_bg_grey.svg") top right no-repeat;
             text-align: center;
         }
         #header {
@@ -211,7 +211,7 @@
         }
 
         footer {
-            background: url("style/img/comms_footer_bg.svg") top left no-repeat;
+            background: url("/style/img/comms_footer_bg.svg") top left no-repeat;
             background-color: #e4e4e4;
             text-align:center;
             padding: 2em 0 2em 0;
@@ -256,7 +256,7 @@
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://agldwg.github.io/website/">Home</a> |
@@ -300,7 +300,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31" />
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31" />
             This web page content is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/broken.html
+++ b/html/broken.html
@@ -4,13 +4,13 @@
     <title>AGLDWG</title>
     <meta charset="utf-8" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -27,7 +27,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/broken.png" alt="broken ico" />
+    <img src="/style/img/broken.png" alt="broken ico" />
     <h1>Broken</h1>
     <h4>The persistent identifier (PID) you resolved, <code style="font-size:larger; font-weight:bold;" id="iri"></code>, is registered but does not redirect anywhere, it is broken.</h4>
     <p>To find out about this PID, search for it in the Australian Government Linked Data Working Group's catalogue of PIDs:</p>
@@ -43,7 +43,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31" />
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31" />
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/environment.data.gov.au.html
+++ b/html/environment.data.gov.au.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -38,7 +38,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/tombstone.svg" alt="tombstone ico" />
+    <img src="/style/img/tombstone.svg" alt="tombstone ico" />
     <h1>environment.data.gov.au, tombstoned</h1>
     <h4>The domain <code style="font-size: larger;">environment.data.gov.au</code> was once a Persistent Identifier (PID) domain that was used to create PIDs for several <a href="https://csiro.au">CSIRO</a> projects in 2018 - 2022.</h4>
     <p>This domain is no longer used and all PIDs associated with it are no longer expected to resolve.</p>
@@ -52,7 +52,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/index.html
+++ b/html/index.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -50,7 +50,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/infrastructure.data.gov.au.html
+++ b/html/infrastructure.data.gov.au.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -38,7 +38,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/tombstone.svg" alt="tombstone ico" />
+    <img src="/style/img/tombstone.svg" alt="tombstone ico" />
     <h1>infrastructure.data.gov.au, tombstoned</h1>
     <h4>The domain <code style="font-size: larger;">infrastructure.data.gov.au</code> was once a Persistent Identifier (PID) domain that was used to create test PIDs, 2018 - 2022.</h4>
     <p>This domain is no longer used and all PIDs associated with it are no longer expected to resolve.</p>
@@ -51,7 +51,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/lab.environment.data.gov.au.html
+++ b/html/lab.environment.data.gov.au.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -38,7 +38,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/tombstone.svg" alt="tombstone ico" />
+    <img src="/style/img/tombstone.svg" alt="tombstone ico" />
     <h1>lab.environment.data.gov.au, tombstoned</h1>
     <h4>The domain <code style="font-size: larger;">lab.environment.data.gov.au</code> was once a Persistent Identifier (PID) domain that was used to create PIDs for a <a href="https://csiro.au">CSIRO</a> and <a href="https://bom.gov.au">Bureau of Meteorology</a> project in 2015 - 2020.</h4>
     <p>This domain is no longer used and all PIDs associated with it are no longer expected to resolve.</p>
@@ -52,7 +52,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/notresolving.html
+++ b/html/notresolving.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" type="image/png" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" type="image/png" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -57,7 +57,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/reference.data.gov.au.html
+++ b/html/reference.data.gov.au.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -38,7 +38,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/tombstone.svg" alt="tombstone ico" />
+    <img src="/style/img/tombstone.svg" alt="tombstone ico" />
     <h1>reference.data.gov.au, tombstoned</h1>
     <h4>The domain <code style="font-size: larger;">reference.data.gov.au</code> was once a Persistent Identifier (PID) domain that was used to create PIDs for several small projects from 2018 until 2022.</h4>
     <p>This domain is no longer used and all PIDs associated with it are no longer expected to resolve.</p>
@@ -52,7 +52,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/html/tombstoned.html
+++ b/html/tombstoned.html
@@ -15,13 +15,13 @@
     <meta name="description" content="A fall-back landing page for AGLDWG-issued PIDs that no-longer resolve" />
     <meta name="generator" content="Lovingly coded by hand" />
 
-    <link rel="icon" href="style/img/agldwg-logo.ico" />
-    <link rel="stylesheet" type="text/css" href="style/agldwg-ochre.css" />
+    <link rel="icon" href="/style/img/agldwg-logo.ico" />
+    <link rel="stylesheet" type="text/css" href="/style/agldwg-ochre.css" />
 </head>
 <body>
 <header id="header" style="text-align:right; padding-top:10px;">
     <div style="width:150px; height:150px; float:left;">
-        <img src="style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
+        <img src="/style/img/agldwg-logo-ochre-150.png" alt="AGLDWG logo" />
     </div>
     <div id="nav">
         <a href="https://www.linked.data.gov.au">Home</a> |
@@ -38,7 +38,7 @@
 </header>
 
 <div id="main" style="clear:both;">
-    <img src="style/img/tombstone.svg" alt="tombstone ico" />
+    <img src="/style/img/tombstone.svg" alt="tombstone ico" />
     <h1>tombstoned</h1>
     <p>The Persistent Identifier (PID) you requested is no longer resolving to any target data or system.</p>
     <p>If you wish to find out more about this resource, please either contact the peopel/organisation you believe to be its owner or contact the <a href="https://www.linked.data.gov.au">Australian Government Linked Data Working Group</a> who maintain the system this PID was created within.</p>
@@ -47,7 +47,7 @@
 <footer>
     <div id="footer-grid">
         <div style="grid-column:1; align-self: end;">
-            <img src="style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
+            <img src="/style/img/cc-by.png" alt="CC BY 4.0" width="88" height="31">
             Content here licensed for use using the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
         </div>
         <div style="grid-column:2; align-self: end; text-align:right; ">

--- a/test-suite/test-runner.py
+++ b/test-suite/test-runner.py
@@ -1,8 +1,13 @@
+# This is the test runner currently in use by the ARDC staging facility.
+
+import glob
+
 import tests.functions_keep_going as functions
 
 if __name__ == "__main__":
     functions.validate_all_redirects("linked.data.gov.au.json")
-    functions.validate_all_redirects("linked.data.gov.au/org/abs.json")
-    functions.validate_all_redirects("linked.data.gov.au/org/gsq.json")
-    functions.validate_all_redirects("linked.data.gov.au/org/gswa.json")
-    functions.validate_all_redirects("linked.data.gov.au/org/tern.json")
+    # All .json files in the linked.data.gov.au/org directory.
+    org_json = glob.glob('linked.data.gov.au/org/*.json')
+    org_json.sort()
+    for org in org_json:
+        functions.validate_all_redirects(org)


### PR DESCRIPTION
Further to commit https://github.com/AGLDWG/pid-proxy/commit/fec6da6e1f7864f3c639a42fe580396b54e2ea35, it turns out that the href attributes
for local resources do need to begin with a slash.  For a 404,
the URL is not rewritten, so if the path is, say, abc/def/ghi, an
href beginning "style/..." would be relative to "abc/def", which
is not what we want ....

Put a slash at the beginning of all those href values.