### PR TITLE
Tern: New rules for dataset and update endpoints

### DIFF
--- a/conf/linked.data.gov.au/org/tern.conf
+++ b/conf/linked.data.gov.au/org/tern.conf
@@ -3,30 +3,30 @@
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
-RewriteRule ^\/dataset\/ausplots(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_mediatype=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
-RewriteRule ^\/dataset\/ausplots(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_mediatype=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
-RewriteRule ^\/dataset\/ausplots(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_mediatype=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
-RewriteRule ^\/dataset\/ausplots(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
 # Notation3
 RewriteCond %{QUERY_STRING} ^_mediatype=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
-RewriteRule ^\/dataset\/ausplots(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
 # .owl file extension
-RewriteRule ^\/dataset\/ausplots(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/ausplots(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/ausplots$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # HTML
 RewriteRule ^/dataset/ausplots(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots$1&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots [R=302,L]
 
@@ -36,30 +36,30 @@ RewriteRule ^/dataset/ausplots(.*)$ https://linkeddata.tern.org.au/viewers/gener
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_mediatype=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_mediatype=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_mediatype=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
 # Notation3
 RewriteCond %{QUERY_STRING} ^_mediatype=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
 # .owl file extension
-RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/tern-ecosystem-processes(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # HTML
 RewriteRule ^/dataset/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes$1&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots [R=302,L]
 
@@ -69,30 +69,30 @@ RewriteRule ^/dataset/tern-ecosystem-processes(.*)$ https://linkeddata.tern.org.
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_mediatype=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_mediatype=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_mediatype=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
 # Notation3
 RewriteCond %{QUERY_STRING} ^_mediatype=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
 # .owl file extension
-RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/wet-tropics-vertebrate(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # HTML
 RewriteRule ^/dataset/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate$1&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots [R=302,L]
 
@@ -102,30 +102,30 @@ RewriteRule ^/dataset/wet-tropics-vertebrate(.*)$ https://linkeddata.tern.org.au
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
-RewriteRule ^\/dataset\/bdbsa(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_mediatype=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
-RewriteRule ^\/dataset\/bdbsa(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_mediatype=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
-RewriteRule ^\/dataset\/bdbsa(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_mediatype=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
-RewriteRule ^\/dataset\/bdbsa(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
 # Notation3
 RewriteCond %{QUERY_STRING} ^_mediatype=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
-RewriteRule ^\/dataset\/bdbsa(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
 # .owl file extension
-RewriteRule ^\/dataset\/bdbsa(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/bdbsa(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/bdbsa$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # HTML
 RewriteRule ^/dataset/bdbsa(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa$1&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots [R=302,L]
 
@@ -163,6 +163,38 @@ RewriteRule ^\/dataset\/three-parks-savanna(.*).owl$ https://linkeddata.tern.org
 RewriteRule ^/dataset/three-parks-savanna(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql [R=302,L]
 
 
+# https://linked.data.gov.au/dataset/nsw-fmip
+# Dataset
+# Turtle
+RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^\/dataset\/nsw-fmip(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/nsw-fmip(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+# RDF/XML
+RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
+RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
+RewriteRule ^\/dataset\/nsw-fmip(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/nsw-fmip(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+# N-Triples
+RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
+RewriteCond %{HTTP:Accept} application/n-triples [NC]
+RewriteRule ^\/dataset\/nsw-fmip(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/nsw-fmip(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+# JSON-LD
+RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
+RewriteCond %{HTTP:Accept} application/ld\+json [NC]
+RewriteRule ^\/dataset\/nsw-fmip(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/nsw-fmip(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+# Notation3
+RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
+RewriteCond %{HTTP:Accept} text/n3 [NC]
+RewriteRule ^\/dataset\/nsw-fmip(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/nsw-fmip(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+# .owl file extension
+RewriteRule ^\/dataset\/nsw-fmip(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/nsw-fmip$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+# HTML
+RewriteRule ^/dataset/nsw-fmip(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql [R=302,L]
+
 # https://linked.data.gov.au/dataset/bioregion
 RewriteRule ^/dataset/bioregion$                              https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/dataset/bioregion/IBRA7 [R=302,QSA,L]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
@@ -188,30 +220,30 @@ RewriteRule ^/dataset/bioregion/(.*)                          https://linkeddata
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
-RewriteRule ^\/dataset\/corveg(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*).ttl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_mediatype=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
-RewriteRule ^\/dataset\/corveg(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*).rdf$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_mediatype=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^\/dataset\/corveg\/(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples [R=302,L]
-RewriteRule ^\/dataset\/corveg\/(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/n-triples
+RewriteRule ^\/dataset\/corveg\/(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/corveg\/(.*).nt$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_mediatype=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
-RewriteRule ^\/dataset\/corveg(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*).jsonld$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
 # Notation3
 RewriteCond %{QUERY_STRING} ^_mediatype=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
-RewriteRule ^\/dataset\/corveg(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*).n3$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
 # .owl file extension
-RewriteRule ^\/dataset\/corveg(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/corveg(.*).owl$ https://linkeddata.tern.org.au/api/v1.0/viewer/resource?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
 # HTML
 RewriteRule ^\/dataset\/corveg(.*)$ https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg$1\&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots [R=302,L]
 

--- a/test-suite/linked.data.gov.au/org/tern.json
+++ b/test-suite/linked.data.gov.au/org/tern.json
@@ -1,119 +1,119 @@
 {
-     "https://linked.data.gov.au/dataset/ausplots": [
-           {
-               "label": "AusPlots Dataset Metadata HTML",
-               "from": "https://linked.data.gov.au/dataset/ausplots",
-               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-               "headers": {}
-           }
-       ],
-     "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
-          {
-               "label": "TERN Ecosystem Processes Dataset Metadata HTML",
-               "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
-               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-               "headers": {}
-          }
+   "https://linked.data.gov.au/dataset/ausplots": [
+         {
+             "label": "AusPlots Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/ausplots",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "headers": {}
+         }
      ],
-     "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
-          {
-               "label": "Wet Tropics Dataset Metadata HTML",
-               "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
-               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/dataset/bdbsa": [
+   "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
         {
-             "label": "BDBSA Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/bdbsa",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "label": "TERN Ecosystem Processes Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
              "headers": {}
         }
-     ],
-     "https://linked.data.gov.au/dataset/three-parks-savanna": [
+   ],
+   "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
         {
-             "label": "Three Parks Savanna Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "label": "Wet Tropics Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
              "headers": {}
         }
-     ],
-     "https://linked.data.gov.au/dataset/nsw-fmip": [
+   ],
+   "https://linked.data.gov.au/dataset/bdbsa": [
+      {
+           "label": "BDBSA Dataset Metadata HTML",
+           "from": "https://linked.data.gov.au/dataset/bdbsa",
+           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+           "headers": {}
+      }
+   ],
+   "https://linked.data.gov.au/dataset/three-parks-savanna": [
+      {
+           "label": "Three Parks Savanna Dataset Metadata HTML",
+           "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
+           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+           "headers": {}
+      }
+   ],
+   "https://linked.data.gov.au/dataset/nsw-fmip": [
+      {
+           "label": "New South Wales Forest Monitoring and improvement Program (NSW-FMIP) Dataset Metadata HTML",
+           "from": "https://linked.data.gov.au/dataset/nsw-fmip",
+           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+           "headers": {}
+      }
+   ],
+   "https://linked.data.gov.au/dataset/bioregion": [],
+   "https://linked.data.gov.au/dataset/corveg": [
         {
-             "label": "New South Wales Forest Monitoring and improvement Program (NSW-FMIP) Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/nsw-fmip",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/corveg",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
              "headers": {}
         }
-     ],
-     "https://linked.data.gov.au/dataset/bioregion": [],
-     "https://linked.data.gov.au/dataset/corveg": [
-          {
-               "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
-               "from": "https://linked.data.gov.au/dataset/corveg",
-               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/def/ausplots-cv": [
-          {
-               "label": "TERN Vocabularies Register HTML",
-               "from": "https://linked.data.gov.au/def/ausplots-cv",
-               "to": "https://linkeddata.tern.org.au/viewer/tern/",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/def/corveg-cv": [
-          {
-               "label": "Queensland CORVEG Database Vocabularies Register HTML",
-               "from": "https://linked.data.gov.au/def/corveg-cv",
-               "to": "https://linkeddata.tern.org.au/viewer/corveg/",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/def/nrm": [
-          {
-               "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
-               "from": "https://linked.data.gov.au/def/nrm",
-               "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/def/plot": [
-          {
-               "label": "TERN Plot Ontology HTML",
-               "from": "https://linked.data.gov.au/def/plot",
-               "to": "https://ternaustralia.github.io/ontology_tern-plot/",
-               "headers": {}
-          },
-          {
-               "label": "TERN Plot Ontology RDF",
-               "from": "https://linked.data.gov.au/def/plot.ttl",
-               "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
-               "headers": {}
-          }
-     ],
-     "https://linked.data.gov.au/def/tern-cv": [
-          {
-               "label": "TERN Vocabularies Register HTML",
-               "from": "https://linked.data.gov.au/def/tern-cv",
-               "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-               "headers": {}
-          },
-          {
-               "label": "TERN Vocabularies Register RDF",
-               "from": "https://linked.data.gov.au/def/tern-cv",
-               "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-               "headers": {
-                   "Accept": "text/turtle"
-               }
-          },
-          {
-               "label": "TERN Vocabularies - one vocab HTML",
-               "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-               "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-               "headers": {}
-          }
-     ]
-   }
+   ],
+   "https://linked.data.gov.au/def/ausplots-cv": [
+        {
+             "label": "TERN Vocabularies Register HTML",
+             "from": "https://linked.data.gov.au/def/ausplots-cv",
+             "to": "https://linkeddata.tern.org.au/viewer/tern/",
+             "headers": {}
+        }
+   ],
+   "https://linked.data.gov.au/def/corveg-cv": [
+        {
+             "label": "Queensland CORVEG Database Vocabularies Register HTML",
+             "from": "https://linked.data.gov.au/def/corveg-cv",
+             "to": "https://linkeddata.tern.org.au/viewer/corveg/",
+             "headers": {}
+        }
+   ],
+   "https://linked.data.gov.au/def/nrm": [
+        {
+             "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
+             "from": "https://linked.data.gov.au/def/nrm",
+             "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
+             "headers": {}
+        }
+   ],
+   "https://linked.data.gov.au/def/plot": [
+        {
+             "label": "TERN Plot Ontology HTML",
+             "from": "https://linked.data.gov.au/def/plot",
+             "to": "https://ternaustralia.github.io/ontology_tern-plot/",
+             "headers": {}
+        },
+        {
+             "label": "TERN Plot Ontology RDF",
+             "from": "https://linked.data.gov.au/def/plot.ttl",
+             "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
+             "headers": {}
+        }
+   ],
+   "https://linked.data.gov.au/def/tern-cv": [
+        {
+             "label": "TERN Vocabularies Register HTML",
+             "from": "https://linked.data.gov.au/def/tern-cv",
+             "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+             "headers": {}
+        },
+        {
+             "label": "TERN Vocabularies Register RDF",
+             "from": "https://linked.data.gov.au/def/tern-cv",
+             "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+             "headers": {
+                 "Accept": "text/turtle"
+             }
+        },
+        {
+             "label": "TERN Vocabularies - one vocab HTML",
+             "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+             "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+             "headers": {}
+        }
+   ]
+ }

--- a/test-suite/linked.data.gov.au/org/tern.json
+++ b/test-suite/linked.data.gov.au/org/tern.json
@@ -1,119 +1,119 @@
 {
-   "https://linked.data.gov.au/dataset/ausplots": [
-         {
-             "label": "AusPlots Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/ausplots",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-             "headers": {}
-         }
-     ],
-   "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
+  "https://linked.data.gov.au/dataset/ausplots": [
         {
-             "label": "TERN Ecosystem Processes Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-             "headers": {}
+            "label": "AusPlots Dataset Metadata HTML",
+            "from": "https://linked.data.gov.au/dataset/ausplots",
+            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+            "headers": {}
         }
-   ],
-   "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
-        {
-             "label": "Wet Tropics Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/dataset/bdbsa": [
-      {
-           "label": "BDBSA Dataset Metadata HTML",
-           "from": "https://linked.data.gov.au/dataset/bdbsa",
-           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-           "headers": {}
-      }
-   ],
-   "https://linked.data.gov.au/dataset/three-parks-savanna": [
-      {
-           "label": "Three Parks Savanna Dataset Metadata HTML",
-           "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
-           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-           "headers": {}
-      }
-   ],
-   "https://linked.data.gov.au/dataset/nsw-fmip": [
-      {
-           "label": "New South Wales Forest Monitoring and improvement Program (NSW-FMIP) Dataset Metadata HTML",
-           "from": "https://linked.data.gov.au/dataset/nsw-fmip",
-           "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-           "headers": {}
-      }
-   ],
-   "https://linked.data.gov.au/dataset/bioregion": [],
-   "https://linked.data.gov.au/dataset/corveg": [
-        {
-             "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
-             "from": "https://linked.data.gov.au/dataset/corveg",
-             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/def/ausplots-cv": [
-        {
-             "label": "TERN Vocabularies Register HTML",
-             "from": "https://linked.data.gov.au/def/ausplots-cv",
-             "to": "https://linkeddata.tern.org.au/viewer/tern/",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/def/corveg-cv": [
-        {
-             "label": "Queensland CORVEG Database Vocabularies Register HTML",
-             "from": "https://linked.data.gov.au/def/corveg-cv",
-             "to": "https://linkeddata.tern.org.au/viewer/corveg/",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/def/nrm": [
-        {
-             "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
-             "from": "https://linked.data.gov.au/def/nrm",
-             "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/def/plot": [
-        {
-             "label": "TERN Plot Ontology HTML",
-             "from": "https://linked.data.gov.au/def/plot",
-             "to": "https://ternaustralia.github.io/ontology_tern-plot/",
-             "headers": {}
-        },
-        {
-             "label": "TERN Plot Ontology RDF",
-             "from": "https://linked.data.gov.au/def/plot.ttl",
-             "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
-             "headers": {}
-        }
-   ],
-   "https://linked.data.gov.au/def/tern-cv": [
-        {
-             "label": "TERN Vocabularies Register HTML",
-             "from": "https://linked.data.gov.au/def/tern-cv",
-             "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-             "headers": {}
-        },
-        {
-             "label": "TERN Vocabularies Register RDF",
-             "from": "https://linked.data.gov.au/def/tern-cv",
-             "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-             "headers": {
-                 "Accept": "text/turtle"
-             }
-        },
-        {
-             "label": "TERN Vocabularies - one vocab HTML",
-             "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-             "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-             "headers": {}
-        }
-   ]
- }
+    ],
+  "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
+       {
+            "label": "TERN Ecosystem Processes Dataset Metadata HTML",
+            "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
+            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
+       {
+            "label": "Wet Tropics Dataset Metadata HTML",
+            "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
+            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/dataset/bdbsa": [
+     {
+          "label": "BDBSA Dataset Metadata HTML",
+          "from": "https://linked.data.gov.au/dataset/bdbsa",
+          "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+          "headers": {}
+     }
+  ],
+  "https://linked.data.gov.au/dataset/three-parks-savanna": [
+     {
+          "label": "Three Parks Savanna Dataset Metadata HTML",
+          "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
+          "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+          "headers": {}
+     }
+  ],
+  "https://linked.data.gov.au/dataset/nsw-fmip": [
+     {
+          "label": "New South Wales Forest Monitoring and improvement Program (NSW-FMIP) Dataset Metadata HTML",
+          "from": "https://linked.data.gov.au/dataset/nsw-fmip",
+          "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+          "headers": {}
+     }
+  ],
+  "https://linked.data.gov.au/dataset/bioregion": [],
+  "https://linked.data.gov.au/dataset/corveg": [
+       {
+            "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
+            "from": "https://linked.data.gov.au/dataset/corveg",
+            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/def/ausplots-cv": [
+       {
+            "label": "TERN Vocabularies Register HTML",
+            "from": "https://linked.data.gov.au/def/ausplots-cv",
+            "to": "https://linkeddata.tern.org.au/viewer/tern/",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/def/corveg-cv": [
+       {
+            "label": "Queensland CORVEG Database Vocabularies Register HTML",
+            "from": "https://linked.data.gov.au/def/corveg-cv",
+            "to": "https://linkeddata.tern.org.au/viewer/corveg/",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/def/nrm": [
+       {
+            "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
+            "from": "https://linked.data.gov.au/def/nrm",
+            "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/def/plot": [
+       {
+            "label": "TERN Plot Ontology HTML",
+            "from": "https://linked.data.gov.au/def/plot",
+            "to": "https://ternaustralia.github.io/ontology_tern-plot/",
+            "headers": {}
+       },
+       {
+            "label": "TERN Plot Ontology RDF",
+            "from": "https://linked.data.gov.au/def/plot.ttl",
+            "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
+            "headers": {}
+       }
+  ],
+  "https://linked.data.gov.au/def/tern-cv": [
+       {
+            "label": "TERN Vocabularies Register HTML",
+            "from": "https://linked.data.gov.au/def/tern-cv",
+            "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+            "headers": {}
+       },
+       {
+            "label": "TERN Vocabularies Register RDF",
+            "from": "https://linked.data.gov.au/def/tern-cv",
+            "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+            "headers": {
+                "Accept": "text/turtle"
+            }
+       },
+       {
+            "label": "TERN Vocabularies - one vocab HTML",
+            "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+            "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+            "headers": {}
+       }
+  ]
+}

--- a/test-suite/linked.data.gov.au/org/tern.json
+++ b/test-suite/linked.data.gov.au/org/tern.json
@@ -1,111 +1,119 @@
 {
-  "https://linked.data.gov.au/dataset/ausplots": [
+     "https://linked.data.gov.au/dataset/ausplots": [
+           {
+               "label": "AusPlots Dataset Metadata HTML",
+               "from": "https://linked.data.gov.au/dataset/ausplots",
+               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+               "headers": {}
+           }
+       ],
+     "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
+          {
+               "label": "TERN Ecosystem Processes Dataset Metadata HTML",
+               "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
+               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
+          {
+               "label": "Wet Tropics Dataset Metadata HTML",
+               "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
+               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/dataset/bdbsa": [
         {
-            "label": "AusPlots Dataset Metadata HTML",
-            "from": "https://linked.data.gov.au/dataset/ausplots",
-            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/ausplots&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots",
-            "headers": {}
+             "label": "BDBSA Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/bdbsa",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "headers": {}
         }
-    ],
-  "https://linked.data.gov.au/dataset/tern-ecosystem-processes": [
-       {
-            "label": "TERN Ecosystem Processes Dataset Metadata HTML",
-            "from": "https://linked.data.gov.au/dataset/tern-ecosystem-processes",
-            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/tern-ecosystem-processes&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/dataset/wet-tropics-vertebrate": [
-       {
-            "label": "Wet Tropics Dataset Metadata HTML",
-            "from": "https://linked.data.gov.au/dataset/wet-tropics-vertebrate",
-            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wet-tropics-vertebrate&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/dataset/bdbsa": [
-     {
-          "label": "BDBSA Dataset Metadata HTML",
-          "from": "https://linked.data.gov.au/dataset/bdbsa",
-          "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/bdbsa&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots",
-          "headers": {}
-     }
-  ],
-  "https://linked.data.gov.au/dataset/three-parks-savanna": [
-     {
-          "label": "Three Parks Savanna Dataset Metadata HTML",
-          "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
-          "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
-          "headers": {}
-     }
-  ],
-  "https://linked.data.gov.au/dataset/bioregion": [],
-  "https://linked.data.gov.au/dataset/corveg": [
-       {
-            "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
-            "from": "https://linked.data.gov.au/dataset/corveg",
-            "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://graphdb.tern.org.au/repositories/ecoplots",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/def/ausplots-cv": [
-       {
-            "label": "TERN Vocabularies Register HTML",
-            "from": "https://linked.data.gov.au/def/ausplots-cv",
-            "to": "https://linkeddata.tern.org.au/viewer/tern/",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/def/corveg-cv": [
-       {
-            "label": "Queensland CORVEG Database Vocabularies Register HTML",
-            "from": "https://linked.data.gov.au/def/corveg-cv",
-            "to": "https://linkeddata.tern.org.au/viewer/corveg/",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/def/nrm": [
-       {
-            "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
-            "from": "https://linked.data.gov.au/def/nrm",
-            "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/def/plot": [
-       {
-            "label": "TERN Plot Ontology HTML",
-            "from": "https://linked.data.gov.au/def/plot",
-            "to": "https://ternaustralia.github.io/ontology_tern-plot/",
-            "headers": {}
-       },
-       {
-            "label": "TERN Plot Ontology RDF",
-            "from": "https://linked.data.gov.au/def/plot.ttl",
-            "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
-            "headers": {}
-       }
-  ],
-  "https://linked.data.gov.au/def/tern-cv": [
-       {
-            "label": "TERN Vocabularies Register HTML",
-            "from": "https://linked.data.gov.au/def/tern-cv",
-            "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-            "headers": {}
-       },
-       {
-            "label": "TERN Vocabularies Register RDF",
-            "from": "https://linked.data.gov.au/def/tern-cv",
-            "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
-            "headers": {
-                "Accept": "text/turtle"
-            }
-       },
-       {
-            "label": "TERN Vocabularies - one vocab HTML",
-            "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-            "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
-            "headers": {}
-       }
-  ]
-}
+     ],
+     "https://linked.data.gov.au/dataset/three-parks-savanna": [
+        {
+             "label": "Three Parks Savanna Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/three-parks-savanna",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/three-parks-savanna&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "headers": {}
+        }
+     ],
+     "https://linked.data.gov.au/dataset/nsw-fmip": [
+        {
+             "label": "New South Wales Forest Monitoring and improvement Program (NSW-FMIP) Dataset Metadata HTML",
+             "from": "https://linked.data.gov.au/dataset/nsw-fmip",
+             "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/nsw-fmip&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+             "headers": {}
+        }
+     ],
+     "https://linked.data.gov.au/dataset/bioregion": [],
+     "https://linked.data.gov.au/dataset/corveg": [
+          {
+               "label": "Queensland Biodiversity and Ecology Information System Dataset Metadata HTML",
+               "from": "https://linked.data.gov.au/dataset/corveg",
+               "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/corveg&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/def/ausplots-cv": [
+          {
+               "label": "TERN Vocabularies Register HTML",
+               "from": "https://linked.data.gov.au/def/ausplots-cv",
+               "to": "https://linkeddata.tern.org.au/viewer/tern/",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/def/corveg-cv": [
+          {
+               "label": "Queensland CORVEG Database Vocabularies Register HTML",
+               "from": "https://linked.data.gov.au/def/corveg-cv",
+               "to": "https://linkeddata.tern.org.au/viewer/corveg/",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/def/nrm": [
+          {
+               "label": "Ecological Monitoring System – Australia (EMSA) Controlled Vocabularies HTML",
+               "from": "https://linked.data.gov.au/def/nrm",
+               "to": "https://linkeddata.tern.org.au/viewers/dawe-vocabs?uri=https://linked.data.gov.au/def/nrm",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/def/plot": [
+          {
+               "label": "TERN Plot Ontology HTML",
+               "from": "https://linked.data.gov.au/def/plot",
+               "to": "https://ternaustralia.github.io/ontology_tern-plot/",
+               "headers": {}
+          },
+          {
+               "label": "TERN Plot Ontology RDF",
+               "from": "https://linked.data.gov.au/def/plot.ttl",
+               "to": "https://raw.githack.com/ternaustralia/ontology_tern-plot/master/docs/tern-plot.ttl",
+               "headers": {}
+          }
+     ],
+     "https://linked.data.gov.au/def/tern-cv": [
+          {
+               "label": "TERN Vocabularies Register HTML",
+               "from": "https://linked.data.gov.au/def/tern-cv",
+               "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+               "headers": {}
+          },
+          {
+               "label": "TERN Vocabularies Register RDF",
+               "from": "https://linked.data.gov.au/def/tern-cv",
+               "to": "https://linkeddata.tern.org.au/viewer/tern/vocabulary/?_view=reg&_format=text/turtle&uri=https://linkeddata.tern.org.au/viewer/tern/vocabulary/",
+               "headers": {
+                   "Accept": "text/turtle"
+               }
+          },
+          {
+               "label": "TERN Vocabularies - one vocab HTML",
+               "from": "https://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+               "to": "https://linkeddata.tern.org.au/viewer/tern/id/http://linked.data.gov.au/def/tern-cv/c3f9024b-18a5-4cda-9b3a-ba9ae7a7d56f",
+               "headers": {}
+          }
+     ]
+   }


### PR DESCRIPTION
Hello all,

This PR contians two main changes:
- Update all tern dataset redirections to use Virtuoso sparql_endpoint
- Added a new set of rules for a new dataset called NSW-FMIP

Related to the new dataset, I have also applied to the creation of the PID, but I am nor sure about the status of that request:
https://catalogue.linked.data.gov.au/resource/330

Thank you very much for your help.
Best regards,
Javier