### PR TITLE
Add catch-all rule to icsm.conf

### DIFF
--- a/conf/linked.data.gov.au/org/icsm.conf
+++ b/conf/linked.data.gov.au/org/icsm.conf
@@ -3,46 +3,49 @@ RewriteRule ^/def/csdm/2022$ "https://icsm-au.github.io/3d-csdm-design/2022/spec
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/commonpatterns($|/.*)$ "https://icsm-au.github.io/3d-csdm/commonpatterns.ttl" [R=302,L]
+RewriteRule ^/def/csdm/commonpatterns$ "https://icsm-au.github.io/3d-csdm/commonpatterns.ttl" [R=302,L]
 RewriteRule ^/def/csdm/commonpatterns.ttl$ "https://icsm-au.github.io/3d-csdm/commonpatterns.ttl" [R=302,L]
 RewriteRule ^/def/csdm/commonpatterns$ "https://icsm-au.github.io/3d-csdm/commonpatterns.html" [R=302,NE,L]
-RewriteRule ^/def/csdm/commonpatterns/(.*)$ "https://icsm-au.github.io/3d-csdm/commonpatterns.html#$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/commonpatterns$ "https://icsm-au.github.io/3d-csdm/commonpatterns.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/container($|/.*)$ "https://icsm-au.github.io/3d-csdm/container.ttl" [R=302,L]
+RewriteRule ^/def/csdm/container$ "https://icsm-au.github.io/3d-csdm/container.ttl" [R=302,L]
 RewriteRule ^/def/csdm/container.ttl$ "https://icsm-au.github.io/3d-csdm/container.ttl" [R=302,L]
-RewriteRule ^/def/csdm/container($|/.*)$ "https://icsm-au.github.io/3d-csdm/container.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/container$ "https://icsm-au.github.io/3d-csdm/container.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/geometryprim($|/.*)$ "https://icsm-au.github.io/3d-csdm/geometryprim.ttl" [R=302,L]
+RewriteRule ^/def/csdm/geometryprim$ "https://icsm-au.github.io/3d-csdm/geometryprim.ttl" [R=302,L]
 RewriteRule ^/def/csdm/geometryprim.ttl$ "https://icsm-au.github.io/3d-csdm/geometryprim.ttl" [R=302,L]
-RewriteRule ^/def/csdm/geometryprim($|/.*)$ "https://icsm-au.github.io/3d-csdm/geometryprim.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/geometryprim$ "https://icsm-au.github.io/3d-csdm/geometryprim.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/parcels($|/.*)$ "https://icsm-au.github.io/3d-csdm/parcels.ttl" [R=302,L]
+RewriteRule ^/def/csdm/parcels$ "https://icsm-au.github.io/3d-csdm/parcels.ttl" [R=302,L]
 RewriteRule ^/def/csdm/parcels.ttl$ "https://icsm-au.github.io/3d-csdm/parcels.ttl" [R=302,L]
-RewriteRule ^/def/csdm/parcels($|/.*)$ "https://icsm-au.github.io/3d-csdm/parcels.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/parcels$ "https://icsm-au.github.io/3d-csdm/parcels.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/surveyfeats($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyfeats.ttl" [R=302,L]
+RewriteRule ^/def/csdm/surveyfeats$ "https://icsm-au.github.io/3d-csdm/surveyfeats.ttl" [R=302,L]
 RewriteRule ^/def/csdm/surveyfeats.ttl$ "https://icsm-au.github.io/3d-csdm/surveyfeats.ttl" [R=302,L]
-RewriteRule ^/def/csdm/surveyfeats($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyfeats.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/surveyfeats$ "https://icsm-au.github.io/3d-csdm/surveyfeats.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/surveyprov($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyprov.ttl" [R=302,L]
+RewriteRule ^/def/csdm/surveyprov$ "https://icsm-au.github.io/3d-csdm/surveyprov.ttl" [R=302,L]
 RewriteRule ^/def/csdm/surveyprov.ttl$ "https://icsm-au.github.io/3d-csdm/surveyprov.ttl" [R=302,L]
-RewriteRule ^/def/csdm/surveyprov($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyprov.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/surveyprov$ "https://icsm-au.github.io/3d-csdm/surveyprov.html" [R=302,NE,L]
 
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/csdm/surveyobs($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyobs.ttl" [R=302,L]
+RewriteRule ^/def/csdm/surveyobs$ "https://icsm-au.github.io/3d-csdm/surveyobs.ttl" [R=302,L]
 RewriteRule ^/def/csdm/surveyobs.ttl$ "https://icsm-au.github.io/3d-csdm/surveyobs.ttl" [R=302,L]
-RewriteRule ^/def/csdm/surveyobs($|/.*)$ "https://icsm-au.github.io/3d-csdm/surveyobs.html$1" [R=302,NE,L]
+RewriteRule ^/def/csdm/surveyobs$ "https://icsm-au.github.io/3d-csdm/surveyobs.html" [R=302,NE,L]
+
+# https://linked.data.gov.au/def/csdm catch-all
+RewriteRule ^/def/csdm/ "https://icsm-au.github.io/3d-csdm/vocab-management.html" [R=302,L]
 
 # https://linked.data.gov.au/def/anzgeodcat
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]


### PR DESCRIPTION
Remove capture group from icsm rules
Add icsm catch-all on /def/csdm/

Capture groups have been removed because the individual classes within each ontology do not have a place to be redirected to yet, and by removing the capture group, any matches will be caught by the catch-all rule.