### PR TITLE
Update DCCEEW BDR dataset redirect, add more tests

### DIFF
--- a/conf/linked.data.gov.au/org/dcceew.conf
+++ b/conf/linked.data.gov.au/org/dcceew.conf
@@ -1,5 +1,5 @@
-# https://linked.data.gov.au/dataset/bdr
-RewriteRule ^/dataset/bdr$                              https://bdrtesting.net/ [R=302,L]
+# https://linked.data.gov.au/dataset/bdr -> https://linked.bdr.gov.au/dataset/bdr
+RewriteRule ^/dataset/bdr($|/.*?$)                      https://linked.bdr.gov.au/dataset/bdr$1?_host=linked.data.gov.au [R=307,QSA,L]
 
 
 # https://linked.data.gov.au/def/nsl

--- a/conf/linked.data.gov.au/org/gswa.conf
+++ b/conf/linked.data.gov.au/org/gswa.conf
@@ -10,9 +10,9 @@ RewriteRule ^/def/gswa-supermodel$ https://kurrawong.github.io/gswa-supermodel/ 
 # https://linked.data.gov.au/def/bore
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^/def/bore$                         https://raw.githubusercontent.com/Kurrawong/gswa-supermodel/main/rdf/components/bore.ttl [R=302,L]
-RewriteRule ^/def/bore.ttl$                     https://raw.githubusercontent.com/Kurrawong/gswa-supermodel/main/rdf/components/bore.ttl [R=302,L]
-RewriteRule ^/def/bore$                         https://kurrawong.github.io/gswa-supermodel/components/bore/ [R=302,L]
+RewriteRule ^/def/bore$                         https://kurrawong.github.io/bore-model/model.ttl [R=302,L]
+RewriteRule ^/def/bore.ttl$                     https://kurrawong.github.io/bore-model/model.ttl [R=302,L]
+RewriteRule ^/def/bore$                         https://kurrawong.github.io/bore-model/model.html [R=302,L]
 
 # https://linked.data.gov.au/def/mine
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]

--- a/test-suite/linked.data.gov.au/org/dcceew.json
+++ b/test-suite/linked.data.gov.au/org/dcceew.json
@@ -3,8 +3,32 @@
     {
       "label": "BDR Dataset HTML",
       "from": "https://linked.data.gov.au/dataset/bdr",
-      "to": "https://bdrtesting.net/",
+      "to": "https://linked.data.gov.au/dataset/bdr?_host=linked.data.gov.au",
       "headers": {}
+    },
+    {
+      "label": "BDR Dataset's Observed Properties Registry entry",
+      "from": "https://linked.data.gov.au/dataset/bdr/obsprops/DatasetsCount",
+      "to": "https://linked.bdr.gov.au/dataset/bdr/obsprops/DatasetsCount?_host=linked.data.gov.au",
+      "headers": {}
+    },
+    {
+      "label": "BDR Registry entry with mediatype",
+      "from": "https://linked.data.gov.au/dataset/bdr/obsprops/DatasetsCount?_mediatype=text/turtle",
+      "to": "https://linked.bdr.gov.au/dataset/bdr/obsprops/DatasetsCount?_host=linked.data.gov.au&_mediatype=text/turtle",
+      "headers": {}
+    },
+    {
+      "label": "BDR Registry entry with profile",
+      "from": "https://linked.data.gov.au/dataset/bdr/obsprops/DatasetsCount?_profile=alt",
+      "to": "https://linked.bdr.gov.au/dataset/bdr/obsprops/DatasetsCount?_host=linked.data.gov.au&_profile=alt",
+      "headers": {}
+    },
+    {
+      "label": "BDR Registry entry with profile and Accept Header",
+      "from": "https://linked.data.gov.au/dataset/bdr/obsprops/DatasetsCount?_profile=alt",
+      "to": "https://linked.bdr.gov.au/dataset/bdr/obsprops/DatasetsCount?_host=linked.data.gov.au&_profile=alt",
+      "headers": {"Accept": "text/turtle"}
     }
   ],
   "http://linked.data.gov.au/def/nsl": [

--- a/test-suite/linked.data.gov.au/org/gswa.json
+++ b/test-suite/linked.data.gov.au/org/gswa.json
@@ -19,13 +19,13 @@
     {
       "label": "bore HTML",
       "from": "https://linked.data.gov.au/def/bore",
-      "to": "https://kurrawong.github.io/gswa-supermodel/components/bore/",
+      "to": "https://kurrawong.github.io/bore-model/model.html",
       "headers": {}
     },
     {
       "label": "bore RDF",
       "from": "https://linked.data.gov.au/def/bore",
-      "to": "https://raw.githubusercontent.com/Kurrawong/gswa-supermodel/main/rdf/components/bore.ttl",
+      "to": "https://kurrawong.github.io/bore-model/model.ttl",
       "headers": {
         "Accept": "text/turtle"
       }


### PR DESCRIPTION
Changed the /dataset/bdr redirect
It now goes to the shiny new DCCEEW BDR PID-Redirector service, aptly hosted at https://linked.bdr.gov.au

I added some tests, but I haven't run the suite personally.
I'm interested to see how the tests perform, because I don't know how the QSA flag (query-string-append) interacts with the `?_host=xyz` param that my redirect adds.

Note, for anyone interested, the reason this redirect adds the `?_host=` query arg is because the new BDR PID redirector can impersonate another host.
Eg, when AGLDWG apache pid-proxy redirects:

`https://linked.data.gov.au/dataset/bdr/xyz  -->  https://linked.bdr.gov.au/dataset/bdr/xyz` 

Then the BDR server will receive a request with the URL "https://linked.bdr.gov.au/dataset/bdr/xyz", however it is a content-aware and identifier-aware service that will try to subsequently redirect the request to a target service.
But that url "https://linked.bdr.gov.au/dataset/bdr/xyz" is not a valid AGLDWG IRI. Now the server can impersonate a different host, when it receives a host override like: https://linked.bdr.gov.au/dataset/bdr/xyz?_host=linked.data.gov.au it will then act as if the `Host` header on the HTTP request is "linked.data.gov.au" and then it can treat the URL as a real BDR IRI and can subsequently redirect it to where it needs to go.