### PR TITLE
fix cors issue

### DIFF
--- a/conf/linked.data.gov.au/linked.conf
+++ b/conf/linked.data.gov.au/linked.conf
@@ -22,8 +22,8 @@
         RewriteRule ^/static/(.*) %{DOCUMENT_ROOT}/$1 [L]
 
         # CORS
-        Header set Access-Control-Allow-Origin "*"
-
+        Header always set Access-Control-Allow-Origin "*"
+        
         #
         # PIDs
         #


### PR DESCRIPTION
Ensures CORS headers are consistently included on 302 redirects by using `Header always set` in Apache config.

This allows simple GET requests from cross-origin clients (e.g. github.io pages) to correctly follow redirects, particularly for vocab resolution.

To test:
https://cors-test.codehappy.dev/?url=https%3A%2F%2Flinked.data.gov.au%2Fdef%2Fcsdm%2Fwa-surveypoint-purpose%2Froad-boundary&origin=https%3A%2F%2Fcors-test.codehappy.dev%2F&method=get