### PR TITLE
Add Wildobs to TERN redirections (with tests)

### DIFF
--- a/conf/linked.data.gov.au/org/tern.conf
+++ b/conf/linked.data.gov.au/org/tern.conf
@@ -353,6 +353,36 @@ RewriteRule ^/dataset/three-parks-savanna(.*)$                      https://link
 
 
 ### -------------------------------------------------------------------------
+## Wildobs --- http://linked.data.gov.au/dataset/wildobs
+# Turtle
+RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^\/dataset\/wildobs(.*)$                    https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+RewriteRule ^\/dataset\/wildobs(.*).ttl$                https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle [R=302,L]
+# RDF/XML
+RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
+RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
+RewriteRule ^\/dataset\/wildobs(.*)$                    https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+RewriteRule ^\/dataset\/wildobs(.*).rdf$                https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/rdf+xml [R=302,L]
+# N-Triples
+RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
+RewriteCond %{HTTP:Accept} application/n-triples [NC]
+RewriteRule ^\/dataset\/wildobs(.*)$                    https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+RewriteRule ^\/dataset\/wildobs(.*).nt$                 https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/n-triples [R=302,L]
+# JSON-LD
+RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
+RewriteCond %{HTTP:Accept} application/ld\+json [NC]
+RewriteRule ^\/dataset\/wildobs(.*)$                    https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+RewriteRule ^\/dataset\/wildobs(.*).jsonld$             https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=application/ld+json [R=302,L]
+# Notation3
+RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
+RewriteCond %{HTTP:Accept} text/n3 [NC]
+RewriteRule ^\/dataset\/wildobs(.*)$                    https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+RewriteRule ^\/dataset\/wildobs(.*).n3$                 https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/n3 [R=302,L]
+# HTML
+RewriteRule ^/dataset/wildobs(.*)$                      https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs$1&sparql_endpoint=https://virtuoso.tern.org.au/sparql [R=302,L]
+
+### -------------------------------------------------------------------------
 ## Wet Tropics Vertebrate http://linked.data.gov.au/dataset/wet-tropics-vertebrate
 # Turtle
 RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]

--- a/test-suite/linked.data.gov.au/org/tern.json
+++ b/test-suite/linked.data.gov.au/org/tern.json
@@ -237,6 +237,22 @@
          }
       }
    ],
+   "https://linked.data.gov.au/dataset/wildobs": [
+      {
+         "label": "WildObs Dataset Metadata - one vocab HTML",
+         "from": "https://linked.data.gov.au/dataset/wildobs",
+         "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs&sparql_endpoint=https://virtuoso.tern.org.au/sparql",
+         "headers": {}
+      },
+      {
+         "label": "WildObs Dataset Metadata - one vocab TURTLE",
+         "from": "https://linked.data.gov.au/dataset/wildobs",
+         "to": "https://linkeddata.tern.org.au/viewers/general?uri=http://linked.data.gov.au/dataset/wildobs&sparql_endpoint=https://virtuoso.tern.org.au/sparql&format=text/turtle",
+         "headers": {
+            "Accept": "text/turtle"
+         }
+      }
+   ],
    "https://linked.data.gov.au/dataset/wet-tropics-vertebrate":[
       {
          "label":"Wet Tropics Dataset Metadata - one vocab HTML",


### PR DESCRIPTION
Hello, 

We would like to add redirections for the new WildObs dataset that will be published by TERN.
I have also requested the creation of the new pid: 

https://catalogue.linked.data.gov.au/resource/495

It's been a long time since we don't request for a new pid and redirections, so apologies if the pipeline is not currently as it used to be or I have done something wrong in the request.

Thanks in advance. Best regards,
Javier S. (TERN)